### PR TITLE
[FIX] Ajuste de redondeo de centavos en total de facturas FEL

### DIFF
--- a/models/account.py
+++ b/models/account.py
@@ -371,6 +371,13 @@ class AccountMove(models.Model):
             TotalImpuesto = etree.SubElement(TotalImpuestos, DTE_NS+"TotalImpuesto", NombreCorto="IVA", TotalMontoImpuesto='{:.6f}'.format(gran_total_impuestos))
             for impuesto in gran_total_impuestos_extras.values():
                 TotalImpuestoExtra = etree.SubElement(TotalImpuestos, DTE_NS+"TotalImpuesto", NombreCorto=impuesto['tipo'], TotalMontoImpuesto='{:.6f}'.format(impuesto['total']))
+
+        # Ajuste de centavos para que el GranTotal del DTE coincida exactamente con el amount_total de la factura en Odoo
+        # Esto evita errores de diferencia de Q0.01 por redondeos internos en precios unitarios.
+        if not factura.currency_id.is_zero(factura.amount_total - gran_total):
+            diferencia = factura.amount_total - gran_total
+            gran_total += diferencia
+
         GranTotal = etree.SubElement(Totales, DTE_NS+"GranTotal")
         GranTotal.text = '{:.6f}'.format(gran_total)
 


### PR DESCRIPTION
Este Pull Request corrige una diferencia de redondeo menor (0.01 Q) que se generaba entre el `amount_total` de Odoo y el total mostrado en el DTE (PDF o XML) enviado a Infile.

El problema ocurría debido a redondeos internos en precios unitarios, descuentos y cálculos de impuestos.

# Solución
Se agrega un pequeño ajuste automático antes de definir el nodo `GranTotal` del DTE.  
Si existe una diferencia menor entre el `gran_total` sumado línea por línea y el `amount_total` oficial de la factura, se corrige agregando esa diferencia.

De esta manera, se garantiza que el DTE no tendrá rechazos por diferencias de un centavo.

# Issue relacionado
Closes #38